### PR TITLE
Consume device-ui as a PIO library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "lib/device-ui"]
-	path = lib/device-ui
-	url = https://github.com/meshtastic/device-ui.git
 [submodule "protobufs"]
 	path = protobufs
 	url = https://github.com/meshtastic/protobufs

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,10 @@
 [platformio]
 default_envs = native_320x240
 
+[device-ui_base]
+lib_deps =
+  https://github.com/meshtastic/device-ui.git#8c3183e177a1d6452ce12b4f328bd3357bf7e21b
+
 [env]
 platform = espressif32@6.9.0
 framework = arduino
@@ -29,8 +33,9 @@ build_flags = -Os
   -DLV_BUILD_TEST=0
   -I src
   -I src/mesh/generated
-lib_deps = lovyan03/LovyanGFX@1.2.0
-
+lib_deps =
+  ${device-ui_base.lib_deps}
+  lovyan03/LovyanGFX@1.2.0
 
 [env:WT32-SC01-PLUS]
 board = wt32-sc01-plus
@@ -52,17 +57,12 @@ build_flags = ${env.build_flags} -O2
   -D VIEW_320x240
   ;-D USE_LANDSCAPE
   -I lib
-  -I lib/device-ui/generated/ui_320x240
   -I lib/mesh/generated
   -I variants/wt32-sc01-plus
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
   -<../lib/comms/packet>
   +<../lib/comms/serial>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -88,16 +88,11 @@ build_flags = ${env.build_flags} -Wl,-Map,output.map -fno-omit-frame-pointer
   -D RAM_SIZE=96
   -D LGFX_DRIVER=LGFX_ESP2432S028RV1
   -D VIEW_320x240
-  -I lib/device-ui/generated/ui_320x240
   -I lib
   -I lib/mesh/generated
   -I variants/esp32_2432S028R
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -123,16 +118,11 @@ build_flags = ${env.build_flags} -Wl,-Map,output.map -fno-omit-frame-pointer
   -D HAS_TFT=1
   -D LGFX_DRIVER=LGFX_ESP2432S028RV2
   -D VIEW_320x240
-  -I lib/device-ui/generated/ui_320x240
   -I lib
   -I lib/mesh/generated
   -I variants/esp32_2432S028R
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -161,16 +151,9 @@ build_flags = ${env.build_flags} -Wl,-Map,output.map -fno-omit-frame-pointer
   -D BUFFER_LINES=100
   -D VIEW_320x240
   -I lib
-  -I lib/device-ui/drivers
-  -I lib/device-ui/generated/ui_320x240
   -I lib/mesh/generated
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/drivers>
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -191,15 +174,10 @@ build_flags = ${env.build_flags} -Os -Wl,-Map,output.map -fno-omit-frame-pointer
   -D HAS_TFT=1
   -D LGFX_DRIVER=LGFX_ESPILI9341XPT2046
   -D VIEW_320x240
-  -I lib/device-ui/generated/ui_320x240
   -I lib
   -I lib/mesh/generated
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -253,14 +231,9 @@ build_flags = ${env.build_flags} -Os -Wl,-Map,output.map -fno-omit-frame-pointer
   -D VIEW_320x240
 ;	-D USE_DOUBLE_BUFFER
   -I lib
-  -I lib/device-ui/generated/ui_320x240
   -I lib/mesh/generated
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -299,15 +272,10 @@ build_flags = ${env.build_flags} -fno-omit-frame-pointer
 ;  -D USE_DOUBLE_BUFFER
   -D LGFX_DRIVER=LGFX_T_HMI
   -D VIEW_320x240
-  -I lib/device-ui/generated/ui_320x240
   -I lib
   -I lib/mesh/generated
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -325,16 +293,11 @@ build_flags = ${env.build_flags}
 ;  -D USE_DOUBLE_BUFFER
   -D LGFX_DRIVER=LGFX_TDECK
   -D VIEW_320x240
-  -I lib/device-ui/generated/ui_320x240
   -I lib
   -I lib/mesh/generated
   -I variants/t-deck
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -352,16 +315,11 @@ build_flags = ${env.build_flags}
   -D LGFX_DRIVER=LGFX_TWATCH_S3
   -D VIEW_240x240
   -D TFT_BL=45
-  -I lib/device-ui/generated/ui_240x240
   -I lib
   -I lib/mesh/generated
   -I variants/t-watch-s3
 build_src_filter = ${env.build_src_filter} 
   +<../lib/mesh>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/generated/ui_240x240>
-  +<../lib/device-ui/generated/ui_240x240/fonts>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -390,15 +348,10 @@ build_flags = ${env.build_flags}
   -D LV_USE_MEM_MONITOR=0
   -D LV_USE_LOG=0
   -I lib
-  -I lib/device-ui/generated/ui_320x240
   -I lib/mesh/generated
   -I variants/seeed-sensecap-indicator
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -434,15 +387,10 @@ build_flags = ${env.build_flags}
   -D LV_USE_LOG=0
   -D HAS_SDCARD=1
   -I lib
-  -I lib/device-ui/generated/ui_320x240
   -I lib/mesh/generated
   -I variants/esp-4848s040
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -476,15 +424,10 @@ build_flags = ${env.build_flags}
   -D LV_USE_MEM_MONITOR=0
   -D LV_USE_LOG=0
   -I lib
-  -I lib/device-ui/generated/ui_320x240
   -I lib/mesh/generated
   -I variants/makerfabs-480x480
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -498,15 +441,11 @@ build_flags = ${env.build_flags}
   -D RAM_SIZE=96
   -D LGFX_DRIVER=LGFX_HELTEC_TRACKER
   -D VIEW_160x80
-  -I lib/device-ui/generated/ui_160x80
   -I lib
   -I lib/mesh/generated
   -I variants/heltec-wireless-tracker
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
-  +<../lib/device-ui/generated/ui_160x80>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
 lib_deps = ${env.lib_deps}
   LittleFS
 
@@ -532,14 +471,8 @@ build_flags = ${env.build_flags} -I.
   -D VIEW_128x64
   -I lib
   -I lib/mesh/generated
-  -I lib/device-ui/generated/ui_128x64
 build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
-  +<../lib/device-ui/generated/ui_128x64>
-  +<../lib/device-ui/generated/ui_128x64/fonts>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
-
 
 [env:native_320x240] ; Linux simulation
 platform = https://github.com/meshtastic/platform-native.git#0e10e92627802594576ce831bb84e3127525b7dd
@@ -566,16 +499,10 @@ build_flags = ${env.build_flags} -O0 -Wall -Wextra -fsanitize=address -lgpiod -l
   -D VIEW_320x240
   -I lib
   -I lib/mesh/generated
-  -I lib/device-ui/generated/ui_320x240
 build_src_filter = ${env.build_src_filter} 
-  +<../lib/device-ui/generated/ui_320x240>
-  +<../lib/device-ui/generated/ui_320x240/fonts>
-  +<../lib/device-ui/resources>
-  +<../lib/device-ui/portduino>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
   +<../lib/log>
 lib_deps =
+  ${device-ui_base.lib_deps}
   https://github.com/lovyan03/LovyanGFX.git#5a39989aa2c9492572255b22f033843ec8900233
   rweather/Crypto@^0.4.0
 
@@ -598,15 +525,9 @@ build_flags = ${env.build_flags} -O0 -Wall -Wextra -fsanitize=address -lgpiod -l
   -D VIEW_240x240
   -I lib
   -I lib/mesh/generated
-  -I lib/device-ui/generated/ui_240x240
 build_src_filter = ${env.build_src_filter}
-  +<../lib/device-ui/generated/ui_240x240/fonts>
-  +<../lib/device-ui/generated/ui_240x240>
-  +<../lib/device-ui/resources>
-  +<../lib/device-ui/portduino>
-  +<../lib/device-ui/source>
-  +<../lib/device-ui/locale>
   +<../lib/log>
 lib_deps =
+  ${device-ui_base.lib_deps}
   https://github.com/lovyan03/LovyanGFX.git#5a39989aa2c9492572255b22f033843ec8900233
   rweather/Crypto@^0.4.0


### PR DESCRIPTION
Same principle as https://github.com/meshtastic/firmware/pull/6193 -- Consume as a PIO library, not a submodule.