### PR TITLE
feat: add framebuffer support (native-fb-mui)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ default_envs = native-mui
 
 [device-ui_base]
 lib_deps =
-  https://github.com/meshtastic/device-ui/archive/272defcb35651461830ebfd1b39c9167c8f49317.zip
+  https://github.com/meshtastic/device-ui/archive/613c0953313bbd236f4ddc5ede447e9edf8e890a.zip
   nanopb/Nanopb@^0.4.91
 
 
@@ -491,7 +491,7 @@ build_src_filter = ${env.build_src_filter}
   +<../lib/mesh>
 
 [env:native-mui]
-platform = https://github.com/meshtastic/platform-native.git#622341c6de8a239704318b10c3dbb00c21a3eab3
+platform = https://github.com/meshtastic/platform-native.git#f566d364204416cdbf298e349213f7d551f793d9
 board = cross_platform
 debug_test = *
 build_flags = ${env.build_flags} -O2 -Wall -Wextra -ffunction-sections -fdata-sections -fPIC -lstdc++fs -lgpiod -lX11 -linput -lxkbcommon -li2c
@@ -510,6 +510,33 @@ build_flags = ${env.build_flags} -O2 -Wall -Wextra -ffunction-sections -fdata-se
   -D LV_USE_MEM_MONITOR=0
   -D LV_USE_PROFILER=0
   -D LV_USE_LIBINPUT=1
+  -D VIEW_320x240
+  -D MAP_FULL_REDRAW
+  -I lib
+  -I lib/mesh/generated
+
+[env:native-fb-mui]
+platform = https://github.com/meshtastic/platform-native.git#f566d364204416cdbf298e349213f7d551f793d9
+board = cross_platform
+debug_test = *
+build_flags = ${env.build_flags} -O2 -Wall -Wextra -ffunction-sections -fdata-sections -fPIC -lstdc++fs -lgpiod -linput -lxkbcommon -li2c
+  -I src/platform/portduino
+  -D RADIOLIB_EEPROM_UNSUPPORTED
+  -D PORTDUINO_LINUX_HARDWARE
+  -D ARCH_PORTDUINO
+  -D USE_ILOG
+  -D HAS_TFT=1
+  -D RAM_SIZE=8192
+  -D USE_FRAMEBUFFER=1
+  -D LV_COLOR_DEPTH=32
+  -D LV_USE_EVDEV=1
+  -D LV_USE_LOG=0
+  -D LV_USE_SYSMON=0
+  -D LV_USE_PERF_MONITOR=0
+  -D LV_USE_MEM_MONITOR=0
+  -D LV_USE_PROFILER=0
+  -D LV_USE_LIBINPUT=1
+  -D LV_CACHE_DEF_SIZE=3145728
   -D VIEW_320x240
   -D MAP_FULL_REDRAW
   -I lib

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,9 +3,9 @@
 #include "Arduino.h"
 #include "Log.h"
 #include "comms/EthClient.h"
-#include "comms/UARTClient.h"
 #include "comms/LinuxSerialClient.h"
 #include "comms/SerialClient.h"
+#include "comms/UARTClient.h"
 #include "graphics/DeviceScreen.h"
 
 #if defined(ARCH_PORTDUINO)
@@ -121,7 +121,11 @@ void portduinoSetup(void)
     if (y < 240 || y > 800)
         y = 480;
 
+#ifdef USE_FRAMEBUFFER
+    screen = &DeviceScreen::create(DisplayDriverConfig(DisplayDriverConfig::device_t::FB, x, y));
+#else
     screen = &DeviceScreen::create(DisplayDriverConfig(DisplayDriverConfig::device_t::X11, x, y));
+#endif
 }
 #endif
 


### PR DESCRIPTION
Allows to directly draw to the (mipi) display via /dev/fb0.

Requires that the display manager is stopped, e.g. for rasbian: 
`sudo systemctl stop lightdm`

Closes #29